### PR TITLE
Added required env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,12 @@
+# Follow the instruuctions in this video to getting the following 5 env vars: https://www.loom.com/share/704ad0689cf2494ebcd427cddb9e6094?t=106
 NEXT_PUBLIC_WHOP_CLIENT_ID="WHOP CLIENT ID"
 WHOP_CLIENT_SECRET="WHOP CLIENT SECRET"
 WHOP_BOT_TOKEN="WHOP API KEY"
-NEXTAUTH_URL="http://localhost:3000"
-NEXTAUTH_SECRET="NEXTAUTH SECRET"
 NEXT_PUBLIC_RECOMMENDED_PLAN_ID="PLAN ID"
 NEXT_PUBLIC_REQUIRED_PASS="PASS ID"
+
+# Generate one here https://generate-secret.vercel.app/
+NEXTAUTH_SECRET=
+
+# Only required in localhost (you can omit this when deploying to Vercel)
+NEXTAUTH_URL="http://localhost:3000"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a [Next.js](https://nextjs.org/) project created using the [`whop-next-t
 
 ## Getting Started
 
-[![Deploy with Vercel](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template&env=NEXT_PUBLIC_WHOP_CLIENT_ID,WHOP_CLIENT_SECRET,WHOP_BOT_TOKEN,NEXT_PUBLIC_RECOMMENDED_PLAN_ID,NEXT_PUBLIC_REQUIRED_PASS,NEXTAUTH_SECRET&envDescription=Follow%20the%20instructions%20here%20to%20obtain%20the%20env%20vars%20above%3A&envLink=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template%2Fblob%2Fmain%2F.env.example&project-name=whop-next-template&repository-name=whop-next-template&demo-title=Whop%20Next.js%20Template&demo-description=Whop%20Next.js%20Template&demo-url=https%3A%2F%2Fnext-template-whop.vercel.app%2F&demo-image=https%3A%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4Xc0tWaSTiUEoRUI6Nyj4C%2F38157dced5977daa0a0ef2e093731023%2Fwhop-nextjs.png%3Fh%3D250)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template&env=NEXT_PUBLIC_WHOP_CLIENT_ID,WHOP_CLIENT_SECRET,WHOP_BOT_TOKEN,NEXT_PUBLIC_RECOMMENDED_PLAN_ID,NEXT_PUBLIC_REQUIRED_PASS,NEXTAUTH_SECRET&envDescription=Follow%20the%20instructions%20here%20to%20obtain%20the%20env%20vars%20above%3A&envLink=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template%2Fblob%2Fmain%2F.env.example&project-name=whop-next-template&repository-name=whop-next-template&demo-title=Whop%20Next.js%20Template&demo-description=Whop%20Next.js%20Template&demo-url=https%3A%2F%2Fnext-template-whop.vercel.app%2F&demo-image=https%3A%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4Xc0tWaSTiUEoRUI6Nyj4C%2F38157dced5977daa0a0ef2e093731023%2Fwhop-nextjs.png%3Fh%3D250)
 
 First, set the required environment variables:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is a [Next.js](https://nextjs.org/) project created using the [`whop-next-t
 
 ## Getting Started
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template)
+[![Deploy with Vercel](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template&env=NEXT_PUBLIC_WHOP_CLIENT_ID,WHOP_CLIENT_SECRET,WHOP_BOT_TOKEN,NEXT_PUBLIC_RECOMMENDED_PLAN_ID,NEXT_PUBLIC_REQUIRED_PASS,NEXTAUTH_SECRET&envDescription=Follow%20the%20instructions%20here%20to%20obtain%20the%20env%20vars%20above%3A&envLink=https%3A%2F%2Fgithub.com%2Fwhopio%2Fnext-template%2Fblob%2Fmain%2F.env.example&project-name=whop-next-template&repository-name=whop-next-template&demo-title=Whop%20Next.js%20Template&demo-description=Whop%20Next.js%20Template&demo-url=https%3A%2F%2Fnext-template-whop.vercel.app%2F&demo-image=https%3A%2F%2Fimages.ctfassets.net%2Fe5382hct74si%2F4Xc0tWaSTiUEoRUI6Nyj4C%2F38157dced5977daa0a0ef2e093731023%2Fwhop-nextjs.png%3Fh%3D250)
 
 First, set the required environment variables:
 


### PR DESCRIPTION
Made some improvements to the Vercel deploy flow by adding a few required env vars in the deploy button & clarifying it in the `.env.example` file.